### PR TITLE
correctly saves job title when new user is created

### DIFF
--- a/lib/HighrisePerson.class.php
+++ b/lib/HighrisePerson.class.php
@@ -29,6 +29,7 @@ require_once('HighriseEntity.class.php');
 			$xml->addChild("company-name",$this->getCompanyName());
 			$xml->addChild("first-name",$this->getFirstName());
 			$xml->addChild("last-name",$this->getLastName());
+			$xml->addChild("title",$this->getTitle());
 			$subject_datas = $xml->addChild("subject_datas");
 			$subject_datas->addAttribute("type", "array");
 			foreach($this->customfields as $custom_field) {


### PR DESCRIPTION
Your implementation doesn't save job titles when a new Person entity is created. This fixes that.
